### PR TITLE
Fix in-class initializers of const floats

### DIFF
--- a/include/private/meta/art_delay.h
+++ b/include/private/meta/art_delay.h
@@ -32,70 +32,70 @@ namespace lsp
     {
         struct art_delay_metadata
         {
-            static const float  TIME_MIN            = 0.0f;
-            static const float  TIME_MAX            = 256.0f;
-            static const float  TIME_STEP           = 0.01f;
-            static const float  TIME_DFL            = 0.0f;
+            static constexpr float  TIME_MIN            = 0.0f;
+            static constexpr float  TIME_MAX            = 256.0f;
+            static constexpr float  TIME_STEP           = 0.01f;
+            static constexpr float  TIME_DFL            = 0.0f;
 
-            static const float  DSEL_MIN            = 0.0f;
-            static const float  DSEL_MAX            = 999.999f;
-            static const float  DSEL_STEP           = 0.01f;
-            static const float  DSEL_DFL            = 0.0f;
+            static constexpr float  DSEL_MIN            = 0.0f;
+            static constexpr float  DSEL_MAX            = 999.999f;
+            static constexpr float  DSEL_STEP           = 0.01f;
+            static constexpr float  DSEL_DFL            = 0.0f;
 
-            static const float  DENOMINATOR_MIN     = 1.0f;
-            static const float  DENOMINATOR_MAX     = 64.0f;
-            static const float  DENOMINATOR_STEP    = 1.0f;
-            static const float  DENOMINATOR_DFL     = 4.0f;
+            static constexpr float  DENOMINATOR_MIN     = 1.0f;
+            static constexpr float  DENOMINATOR_MAX     = 64.0f;
+            static constexpr float  DENOMINATOR_STEP    = 1.0f;
+            static constexpr float  DENOMINATOR_DFL     = 4.0f;
 
-            static const float  FRACTION_MIN        = 0.0f;
-            static const float  FRACTION_MAX        = 2.0f;
-            static const float  FRACTION_STEP       = 1.0f / 64.0f;
-            static const float  FRACTION_DFL        = 0.0f;
+            static constexpr float  FRACTION_MIN        = 0.0f;
+            static constexpr float  FRACTION_MAX        = 2.0f;
+            static constexpr float  FRACTION_STEP       = 1.0f / 64.0f;
+            static constexpr float  FRACTION_DFL        = 0.0f;
 
-            static const float  DFRACTION_MIN       = 0.0f;
-            static const float  DFRACTION_MAX       = 2.0f;
-            static const float  DFRACTION_STEP      = 1.0f / 64.0f;
-            static const float  DFRACTION_DFL       = 1.0f;
+            static constexpr float  DFRACTION_MIN       = 0.0f;
+            static constexpr float  DFRACTION_MAX       = 2.0f;
+            static constexpr float  DFRACTION_STEP      = 1.0f / 64.0f;
+            static constexpr float  DFRACTION_DFL       = 1.0f;
 
-            static const float  BAR_MULT_MIN        = 0.0f;
-            static const float  BAR_MULT_MAX        = 1000.0f;
-            static const float  BAR_MULT_STEP       = 0.5f;
-            static const float  BAR_MULT_DFL        = 1.0f;
+            static constexpr float  BAR_MULT_MIN        = 0.0f;
+            static constexpr float  BAR_MULT_MAX        = 1000.0f;
+            static constexpr float  BAR_MULT_STEP       = 0.5f;
+            static constexpr float  BAR_MULT_DFL        = 1.0f;
 
-            static const float  DELAY_MULT_MIN      = 0.0f;
-            static const float  DELAY_MULT_MAX      = 1000.0f;
-            static const float  DELAY_MULT_STEP     = 0.1f;
-            static const float  DELAY_MULT_DFL      = 1.0f;
+            static constexpr float  DELAY_MULT_MIN      = 0.0f;
+            static constexpr float  DELAY_MULT_MAX      = 1000.0f;
+            static constexpr float  DELAY_MULT_STEP     = 0.1f;
+            static constexpr float  DELAY_MULT_DFL      = 1.0f;
 
-            static const float  ATEMPO_MIN          = 0.0f;
-            static const float  ATEMPO_MAX          = 9000.0f;
-            static const float  ATEMPO_STEP         = 0.1f;
-            static const float  ATEMPO_DFL          = 120.0f;
+            static constexpr float  ATEMPO_MIN          = 0.0f;
+            static constexpr float  ATEMPO_MAX          = 9000.0f;
+            static constexpr float  ATEMPO_STEP         = 0.1f;
+            static constexpr float  ATEMPO_DFL          = 120.0f;
 
-            static const float  TEMPO_MIN           = 20.0f;
-            static const float  TEMPO_MAX           = 360.0f;
-            static const float  TEMPO_STEP          = 0.05f;
-            static const float  TEMPO_DFL           = 120.0f;
+            static constexpr float  TEMPO_MIN           = 20.0f;
+            static constexpr float  TEMPO_MAX           = 360.0f;
+            static constexpr float  TEMPO_STEP          = 0.05f;
+            static constexpr float  TEMPO_DFL           = 120.0f;
 
-            static const float  BAND_GAIN_MIN       = GAIN_AMP_M_24_DB;
-            static const float  BAND_GAIN_MAX       = GAIN_AMP_P_24_DB;
-            static const float  BAND_GAIN_STEP      = 0.025f;
-            static const float  BAND_GAIN_DFL       = GAIN_AMP_0_DB;
+            static constexpr float  BAND_GAIN_MIN       = GAIN_AMP_M_24_DB;
+            static constexpr float  BAND_GAIN_MAX       = GAIN_AMP_P_24_DB;
+            static constexpr float  BAND_GAIN_STEP      = 0.025f;
+            static constexpr float  BAND_GAIN_DFL       = GAIN_AMP_0_DB;
 
-            static const float  LOW_CUT_MIN         = SPEC_FREQ_MIN;
-            static const float  LOW_CUT_MAX         = 1000.0f;
-            static const float  LOW_CUT_STEP        = 0.001f;
-            static const float  LOW_CUT_DFL         = 100.0f;
+            static constexpr float  LOW_CUT_MIN         = SPEC_FREQ_MIN;
+            static constexpr float  LOW_CUT_MAX         = 1000.0f;
+            static constexpr float  LOW_CUT_STEP        = 0.001f;
+            static constexpr float  LOW_CUT_DFL         = 100.0f;
 
-            static const float  HIGH_CUT_MIN        = 1000.0f;
-            static const float  HIGH_CUT_MAX        = SPEC_FREQ_MAX;
-            static const float  HIGH_CUT_STEP       = 0.001f;
-            static const float  HIGH_CUT_DFL        = 8000.0f;
+            static constexpr float  HIGH_CUT_MIN        = 1000.0f;
+            static constexpr float  HIGH_CUT_MAX        = SPEC_FREQ_MAX;
+            static constexpr float  HIGH_CUT_STEP       = 0.001f;
+            static constexpr float  HIGH_CUT_DFL        = 8000.0f;
 
-            static const float  MEMORY_MIN          = 0.0f;
-            static const float  MEMORY_MAX          = 65536.0f;
-            static const float  MEMORY_DFL          = 0.0f;
-            static const float  MEMORY_STEP         = 0.01f;
+            static constexpr float  MEMORY_MIN          = 0.0f;
+            static constexpr float  MEMORY_MAX          = 65536.0f;
+            static constexpr float  MEMORY_DFL          = 0.0f;
+            static constexpr float  MEMORY_STEP         = 0.01f;
 
             static const size_t EQ_BANDS            = 5;
 


### PR DESCRIPTION
include/private/meta/art_delay.h:
Change all in-class initializers of static float members to use
constexpr, which is compatible with C++11.

Relates to https://github.com/sadko4u/lsp-plugins/issues/257